### PR TITLE
Add research team members

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,14 @@
 # Research at Web3 Foundation
 
-Web3 Foundation Research is being done in an in-house research team as well as in collaboration with various projects and research groups. The in-house team is mostly located in Zug, Switzerland. 
+Web3 Foundation Research is being done in an in-house research team as well as in collaboration with various projects and research groups. The in-house team is mostly located in Zug, Switzerland.
 
-Our research generally focuses on areas of:  
-- Decentralised algorithms: consensus, optimization, game theory  
-- Cryptography  
-- Networking  
+Our research generally focuses on areas of:
+- Decentralised algorithms: consensus, optimization, game theory
+- Cryptography
+- Networking
 
-Some of our current initiatives:  
-- [Polkadot network protocol research](polkadot)  
-- [Messaging for Web3 initiative](https://github.com/w3f/messaging)  
+Some of our current initiatives:
+- [Polkadot network protocol research](polkadot)
+- [Messaging for Web3 initiative](https://github.com/w3f/messaging)
 
 Talk to us on Riot at #w3f:matrix.org or on our [forum](https://forum.web3.foundation/).
-

--- a/docs/research_team_members/alfonso.md
+++ b/docs/research_team_members/alfonso.md
@@ -1,0 +1,1 @@
+# Alfonso Cevallos Manzano

--- a/docs/research_team_members/alistair.md
+++ b/docs/research_team_members/alistair.md
@@ -1,0 +1,1 @@
+# Alistair Stewart

--- a/docs/research_team_members/fatemeh.md
+++ b/docs/research_team_members/fatemeh.md
@@ -1,0 +1,1 @@
+# Fatemeh Shirazi

--- a/docs/research_team_members/handan.md
+++ b/docs/research_team_members/handan.md
@@ -1,0 +1,1 @@
+# Handan Kilinc Alper

--- a/docs/research_team_members/jeff.md
+++ b/docs/research_team_members/jeff.md
@@ -1,0 +1,1 @@
+# Jeff Burdges

--- a/docs/research_team_members/syed.md
+++ b/docs/research_team_members/syed.md
@@ -1,0 +1,1 @@
+# Syed Hosseini Lavasani

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,7 +26,7 @@ theme:
   logo: 'images/w3f_logo.svg'
   feature: false
 
-  # Extra css for further customization 
+  # Extra css for further customization
 extra_css:
   - 'stylesheets/extra.css'
 


### PR DESCRIPTION
This will add empty documents for each of the team members and links on the left side menu. 

@FatemeShirazi is it ok to add the document of each researcher empty? If so we can merge this and add content later, let me know.