### PR TITLE
Expand Candidate Selection section

### DIFF
--- a/docs/polkadot/implementors-guide/guide.md
+++ b/docs/polkadot/implementors-guide/guide.md
@@ -913,7 +913,7 @@ Furthermore, the protocols by which subsystems communicate with each other shoul
 
 #### Description
 
-The Candidate Backing subsystem determines whether parachain blocks are valid or not. When run as a validator or fisherman, this subsystem actually validates incoming candidates.
+The Candidate Backing subsystem ensures at least one preliminary validator commits to each parablock's correctness. Parablocks for which no validator will assert correctness are discarded. If the block later proves invalid, the initial backers are slashable; this gives polkadot a rational threat model during subsequent stages.
 
 Its role is to produce backed candidates for inclusion in new relay-chain blocks. It does so by issuing signed [Statements](#Statement-type) and tracking received statements signed by other validators. Once enough statements are received, they can be combined into backing for specific candidates.
 

--- a/docs/polkadot/implementors-guide/guide.md
+++ b/docs/polkadot/implementors-guide/guide.md
@@ -947,7 +947,7 @@ This will probably blur the lines between jobs, will probably require inter-job 
 
 The Candidate Backing Job represents the work a node does for backing candidates with respect to a particular relay-parent.
 
-The goal of a Candidate Backing Job is to produce as many backed candidates as possible. This is done via signed [Statements](#Statement-type) by validators. If a candidate receives a majority of supporting Statements from the Parachain Validators currently assigned, then that candidate is considered backed.
+The goal of a Candidate Backing Job is to produce as many accurate [Statements](#Statement-type) about candidates as possible. If a candidate receives a majority of supporting Statements from the Parachain Validators currently assigned, then that candidate is considered backed.
 
 *on startup*
 * Fetch current validator set, validator -> parachain assignments from runtime API.

--- a/docs/polkadot/implementors-guide/guide.md
+++ b/docs/polkadot/implementors-guide/guide.md
@@ -917,8 +917,6 @@ The Candidate Backing subsystem determines whether parachain blocks are valid or
 
 Its role is to produce backed candidates for inclusion in new relay-chain blocks. It does so by issuing signed [Statements](#Statement-type) and tracking received statements signed by other validators. Once enough statements are received, they can be combined into backing for specific candidates.
 
-It also detects double-vote misbehavior by validators as it imports votes, passing on the misbehavior to the correct reporter and handler.
-
 #### Protocol
 
 The **Candidate Selection** subsystem is the primary source of non-overseer messages into this subsystem. That subsystem generates appropriate [`CandidateBackingSubsystemMessage`s](#Candidate-Backing-Subsystem-Message), and passes them to this subsystem.
@@ -1008,8 +1006,10 @@ This module is only ever interested in parablocks assigned to the particular par
 New parablock candidates may arrive from a potentially unbounded set of collators. This subsystem chooses either 0 or 1 of them per relay parent to second. If it chooses to second a candidate, it sends an apropriate message to the **Candidate Backing** subsystem to generate an appropriate `Statement`.
 
 All parablocks which peers have seconded are also sent to the Candidate Backing subsystem for re-validation.
+As seconded peers are tallied, double-votes are detected. If found, a report is sent to the **Misbehavior Arbitration** subsystem.
 
 In the event that a parablock candidate proves invalid, this subsystem will receive a message back from the Candidate Backing subsystem indicating so. If that parablock candidate originated from a collator, this subsystem will blacklist that collator. If that parablock candidate originated from a peer, this subsystem generates a report for the **Misbehavior Arbitration** subsystem.
+
 
 TODO: more details, protocol, etc
 

--- a/docs/polkadot/implementors-guide/guide.md
+++ b/docs/polkadot/implementors-guide/guide.md
@@ -138,14 +138,14 @@ In this example, group 1 has received block C while the others have not due to n
    .        (Validator 5)             .
    .                                  .
    ....... Building on C and C' .......
-           
-            +----------------------+         +----------------------+       
-            |    Relay Block C     |         |    Relay Block C'    |          
+
+            +----------------------+         +----------------------+
+            |    Relay Block C     |         |    Relay Block C'    |
             +----------------------+         +----------------------+
                             \                 /
-                             \               /   
+                             \               /
                               \             /
-                      +----------------------+    
+                      +----------------------+
                       |  Relay Block B       |
                       +----------------------+
 	                             |
@@ -181,7 +181,7 @@ Our Parachain Host includes a blockchain known as the relay-chain. A blockchain 
                                 +----------------+
                                 |    Genesis     |
                                 +----------------+
-```                                
+```
 
 
 A blockchain network is comprised of nodes. These nodes each have a view of many different forks of a blockchain and must decide which forks to follow and what actions to take based on the forks of the chain that they are aware of.
@@ -235,7 +235,7 @@ It is also helpful to divide Node-side behavior into two further categories: Net
                                                    ______| |______
                                                    ___Transport___
 
-```                                                   
+```
 
 
 Node-side behavior is split up into various subsystems. Subsystems are long-lived workers that perform a particular category of work. Subsystems can communicate with each other, and do so via an Overseer that prevents race conditions.
@@ -292,7 +292,7 @@ initialization:
   * determine scheduled parachains and parathreads for the upcoming block or blocks.
   * determine validator assignments to scheduled paras for the upcoming block or blocks.
   * remove blocks which have been pending availability for too long. this is tightly coupled with scheduling.
-  * handle the start of a new session - discard all candidates pending availability and note the upcoming validator set. 
+  * handle the start of a new session - discard all candidates pending availability and note the upcoming validator set.
   * apply calls from upward messages - messages from parachains to the relay chain.
 
 during the block:
@@ -302,7 +302,7 @@ during the block:
 
 process availability bitfields:
   * We will accept an optional signed bitfield from each validator in each block.
-  * We need to check the signature and length of the bitfield for validity. 
+  * We need to check the signature and length of the bitfield for validity.
   * We will keep the most recent bitfield for each validator in the session. Each bit corresponds to a particular parachain candidate pending availability. Parachains are scheduled on every block, so we can assign a bit to each one of those. Parathreads are not scheduled on every block, and there may be a lot of them, so we probably don't want a dedicated bit in the bitfield for those. Since we want an upper bound on the number of parathreads we have scheduled or pending availability, a concept of "execution cores" used in scheduling (TODO) should be reusable here - have a dedicated bit in the bitfield for each core, and each core will be assigned to a different parathread over time.
   * Bits that are set to `true` denote candidate pending availability which are believed by this validator to be available.
   * Candidates that are pending availability and have the corresponding bit set in 2/3 of validators' bitfields (only counting those submitted after the candidate was included, since some validators may not have submitted bitfields in some time) are considered available and are then moved into the "pending approval" state.
@@ -316,8 +316,8 @@ candidates entering the "pending approval" state:
 
 process new backed candidates:
   * ensure that only one candidate is backed for each parachain or parathread
-  * ensure that the parachain or parathread of the candidate was scheduled and does not currently have a block pending availability. 
-  * check the backing of the candidate. 
+  * ensure that the parachain or parathread of the candidate was scheduled and does not currently have a block pending availability.
+  * check the backing of the candidate.
   * move to "pending approval" state. (pass along any configuration information that is liable to change)
 
 misbehavior reports and secondary checks:
@@ -366,7 +366,7 @@ The Initializer module is special - it's responsible for handling the initializa
 The Parachain Host operates under a changing set of validators. Time is split up into periodic sessions, where each session brings a potentially new set of validators. Sessions are buffered by one, meaning that the validators of the upcoming session are fixed and always known. Parachain Host runtime modules need to react to changes in the validator set, as it will affect the runtime logic for processing candidate backing, availability bitfields, and misbehavior reports. The Parachain Host modules can't determine ahead-of-time exactly when session change notifications are going to happen within the block (note: this depends on module initialization order again - better to put session before parachains modules). Ideally, session changes are always handled before initialization. It is clearly a problem if we compute validator assignments to parachains during initialization and then the set of validators changes. In the best case, we can recognize that re-initialization needs to be done. In the worst case, bugs would occur.
 
 There are 3 main ways that we can handle this issue:
-  1. Establish an invariant that session change notifications always happen after initialization. This means that when we receive a session change notification before initialization, we call the initialization routines before handling the session change. 
+  1. Establish an invariant that session change notifications always happen after initialization. This means that when we receive a session change notification before initialization, we call the initialization routines before handling the session change.
   2. Require that session change notifications always occur before initialization. Brick the chain if session change notifications ever happen after initialization.
   3. Handle both the before and after cases.
 
@@ -383,7 +383,7 @@ So the other role of the initializer module is to forward session change notific
 
 #### Description
 
-This module is responsible for initializing the other modules in a deterministic order. It also has one other purpose as described above: accepting and forwarding session change notifications. 
+This module is responsible for initializing the other modules in a deterministic order. It also has one other purpose as described above: accepting and forwarding session change notifications.
 
 #### Storage
 
@@ -535,7 +535,7 @@ OutgoingParas: Vec<ParaId>;
 
 1. Clean up outgoing paras. This means removing the entries under `Heads`, `ValidationCode`, `FutureCodeUpgrades`, and `FutureCode`. An according entry should be added to `PastCode`, `PastCodeMeta`, and `PastCodePruning` using the outgoing `ParaId` and removed `ValidationCode` value. This is because any outdated validation code must remain available on-chain for a determined amount of blocks, and validation code outdated by de-registering the para is still subject to that invariant.
 1. Apply all incoming paras by initializing the `Heads` and `ValidationCode` using the genesis parameters.
-1. Amend the `Parachains` list to reflect changes in registered parachains. 
+1. Amend the `Parachains` list to reflect changes in registered parachains.
 
 #### Initialization
 
@@ -545,7 +545,7 @@ OutgoingParas: Vec<ParaId>;
 
 * `schedule_para_initialize(ParaId, ParaGenesisArgs)`: schedule a para to be initialized at the next session.
 * `schedule_para_cleanup(ParaId)`: schedule a para to be cleaned up at the next session.
-* `schedule_code_upgrade(ParaId, ValidationCode, expected_at: BlockNumber)`: Schedule a future code upgrade of the given parachain, to be applied after inclusion of a block of the same parachain executed in the context of a relay-chain block with number >= `expected_at`. 
+* `schedule_code_upgrade(ParaId, ValidationCode, expected_at: BlockNumber)`: Schedule a future code upgrade of the given parachain, to be applied after inclusion of a block of the same parachain executed in the context of a relay-chain block with number >= `expected_at`.
 * `note_new_head(ParaId, HeadData, BlockNumber)`: note that a para has progressed to a new head, where the new head was executed in the context of a relay-chain block with given number. This will apply pending code upgrades based on the block number provided.
 * `validation_code_at(ParaId, at: BlockNumber, assume_intermediate: Option<BlockNumber>)`: Fetches the validation code to be used when validating a block in the context of the given relay-chain height. A second block number parameter may be used to tell the lookup to proceed as if an intermediate parablock has been included at the given relay-chain height. This may return past, current, or (with certain choices of `assume_intermediate`) future code. `assume_intermediate`, if provided, must be before `at`. If `at` is too old or the `ParaId` does not reference any live para, this may return `None`.
 
@@ -571,48 +571,48 @@ It aims to achieve these tasks with these goals in mind:
 
 The Scheduler manages resource allocation using the concept of "Execution Cores". There will be one execution core for each parachain, and a fixed number of cores used for multiplexing parathreads. Validators will be partitioned into groups, with the same number of groups as execution cores. Validator groups will be assigned to different execution cores over time.
 
-An execution core can exist in either one of two states at the beginning or end of a block: free or occupied. A free execution core can have a parachain or parathread assigned to it for the potential to have a backed candidate included. After inclusion, the core enters the occupied state as the backed candidate is pending availability. There is an important distinction: a core is not considered occupied until it is in charge of a block pending availability, although the implementation may treat scheduled cores the same as occupied ones for brevity. A core exits the occupied state when the candidate is no longer pending availability - either on timeout or on availability. A core starting in the occupied state can move to the free state and back to occupied all within a single block, as availability bitfields are processed before backed candidates. At the end of the block, there is a possible timeout on availability which can move the core back to the free state if occupied. 
+An execution core can exist in either one of two states at the beginning or end of a block: free or occupied. A free execution core can have a parachain or parathread assigned to it for the potential to have a backed candidate included. After inclusion, the core enters the occupied state as the backed candidate is pending availability. There is an important distinction: a core is not considered occupied until it is in charge of a block pending availability, although the implementation may treat scheduled cores the same as occupied ones for brevity. A core exits the occupied state when the candidate is no longer pending availability - either on timeout or on availability. A core starting in the occupied state can move to the free state and back to occupied all within a single block, as availability bitfields are processed before backed candidates. At the end of the block, there is a possible timeout on availability which can move the core back to the free state if occupied.
 
 ```
 Execution Core State Machine
-                                       
-              Assignment &              
-              Backing                   
+
+              Assignment &
+              Backing
 +-----------+              +-----------+
 |           +-------------->           |
 |  Free     |              | Occupied  |
 |           <--------------+           |
 +-----------+ Availability +-----------+
-              or Timeout                
-                                        
+              or Timeout
+
 ```
 
 ```
 Execution Core Transitions within Block
-                                                                                             
-              +-----------+                |                    +-----------+                
-              |           |                |                    |           |                
-              | Free      |                |                    | Occupied  |                
-              |           |                |                    |           |                
-              +--/-----\--+                |                    +--/-----\--+                
-               /-       -\                 |                     /-       -\                 
+
+              +-----------+                |                    +-----------+
+              |           |                |                    |           |
+              | Free      |                |                    | Occupied  |
+              |           |                |                    |           |
+              +--/-----\--+                |                    +--/-----\--+
+               /-       -\                 |                     /-       -\
  No Backing  /-           \ Backing        |      Availability /-           \ No availability
-           /-              \               |                  /              \               
-         /-                 -\             |                /-                -\             
-  +-----v-----+         +----v------+      |         +-----v-----+        +-----v-----+      
-  |           |         |           |      |         |           |        |           |      
-  | Free      |         | Occupied  |      |         | Free      |        | Occupied  |      
-  |           |         |           |      |         |           |        |           |      
-  +-----------+         +-----------+      |         +-----|---\-+        +-----|-----+      
-                                           |               |    \               |            
+           /-              \               |                  /              \
+         /-                 -\             |                /-                -\
+  +-----v-----+         +----v------+      |         +-----v-----+        +-----v-----+
+  |           |         |           |      |         |           |        |           |
+  | Free      |         | Occupied  |      |         | Free      |        | Occupied  |
+  |           |         |           |      |         |           |        |           |
+  +-----------+         +-----------+      |         +-----|---\-+        +-----|-----+
+                                           |               |    \               |
                                            |    No backing |     \ Backing      | (no change)
-                                           |               |      -\            |            
-                                           |         +-----v-----+  \     +-----v-----+      
-                                           |         |           |   \    |           |      
-                                           |         | Free      -----+---> Occupied  |      
-                                           |         |           |        |           |      
-                                           |         +-----------+        +-----------+      
-                                           |                 Availability Timeout            
+                                           |               |      -\            |
+                                           |         +-----v-----+  \     +-----v-----+
+                                           |         |           |   \    |           |
+                                           |         | Free      -----+---> Occupied  |
+                                           |         |           |        |           |
+                                           |         +-----------+        +-----------+
+                                           |                 Availability Timeout
 ```
 
 Validator group assignments do not need to change very quickly. The security benefits of fast rotation is redundant with the challenge mechanism in the Validity module. Because of this, we only divide validators into groups at the beginning of the session and do not shuffle membership during the session. However, we do take steps to ensure that no particular validator group has dominance over a single parachain or parathread-multiplexer for an entire session to provide better guarantees of liveness.
@@ -630,7 +630,7 @@ Parathread claims, when scheduled onto a free core, may not result in a block pe
 Cores are treated as an ordered list of cores and are typically referred to by their index in that list.
 
 [
-  
+
   TODO: Validator assignment. We want to assign validators to chains, not to cores. Assigning to cores means that for parathread cores, the parathread is unclear until late in the process so that would have bad implications for networking.
 
   We can prepare a set of chains by assigning all unassigned cores, optimistically assigning all previously assigned cores, and then taking the union of those sets. However, this means that validator assignment is not possible to know until the beginning of the block. Ideally, we'd always know about at least a couple of blocks in advance, which makes networking discovery easier. However, optimistic assignment seems incompatible with this goal.
@@ -668,7 +668,7 @@ ValidatorGroups: Vec<Vec<ValidatorIndex>>;
 ParathreadQueue: Vec<ParathreadEntry>;
 /// One entry for each execution core. Entries are `None` if the core is not currently occupied. Can be
 /// temporarily `Some` if scheduled but not occupied.
-/// The i'th parachain belongs to the i'th core, with the remaining cores all being 
+/// The i'th parachain belongs to the i'th core, with the remaining cores all being
 /// parathread-multiplexers.
 ExecutionCores: Vec<Option<CoreOccupied>>;
 /// An index used to ensure that only one claim on a parathread exists in the queue or retry queue or is
@@ -712,13 +712,13 @@ Actions:
 * `group_validators(GroupIndex) -> Vec<ValidatorIndex>`
 
 ### The Inclusion Module
- 
+
 #### Description
- 
+
 The inclusion module is responsible for inclusion and availability of scheduled parachains and parathreads.
 
 
-#### Storage 
+#### Storage
 
 Helper structs:
 ```rust
@@ -760,12 +760,12 @@ All failed checks should lead to an unrecoverable error making the block invalid
     1. check that the number of bitfields and bits in each bitfield is correct.
     1. check that there are no duplicates
     1. check all validator signatures.
-    1. apply each bit of bitfield to the corresponding pending candidate. looking up parathread cores using the `Scheduler` module. Disregard bitfields that have a `1` bit for any free cores. 
+    1. apply each bit of bitfield to the corresponding pending candidate. looking up parathread cores using the `Scheduler` module. Disregard bitfields that have a `1` bit for any free cores.
     1. For each applied bit of each availability-bitfield, set the bit for the validator in the `CandidatePendingAvailability`'s `availability_votes` bitfield. Track all candidates that now have >2/3 of bits set in their `availability_votes`. These candidates are now available and can be enacted.
     1. For all now-available candidates, invoke the `enact_candidate` routine with the candidate and relay-parent number.
     1. If any candidates have become available, invoke `Scheduler::schedule(freed)` where `freed` is the list of freed cores.
     1. [TODO] pass it onwards to `Validity` module.
-  * `process_candidates(BackedCandidates)`: 
+  * `process_candidates(BackedCandidates)`:
     1. Get all scheduled cores using `Scheduler::scheduled`.
     1. check that each candidate corresponds to a scheduled core and that they are ordered in ascending order by `ParaId`.
     1. check the backing of the candidate using the signatures and the bitfields.
@@ -792,22 +792,22 @@ All failed checks should lead to an unrecoverable error making the block invalid
     signature: ValidatorSignature, // signature is on payload: bitfield ++ relay_parent ++ validator index
   }
   struct Bitfields(Vec<(SignedAvailabilityBitfield)>), // bitfields sorted by validator index, ascending
-  
+
   enum ValidityAttestation {
     /// Implicit validity attestation by issuing.
     /// This corresponds to issuance of a `Seconded` statement.
     Implicit(ValidatorSignature),
     /// An explicit attestation. This corresponds to issuance of a
     /// `Valid` statement.
-    Explicit(ValidatorSignature),    
+    Explicit(ValidatorSignature),
   }
-  
+
   struct BackedCandidate {
     candidate: AbridgedCandidateReceipt,
     validity_votes: Vec<ValidityAttestation>,
-    // the indices of validators who signed the candidate within the group. There is no need to include 
+    // the indices of validators who signed the candidate within the group. There is no need to include
     // bit for any validators who are not in the group, so this is more compact.
-    validator_indices: BitVec, 
+    validator_indices: BitVec,
   }
 
   struct BackedCandidates(Vec<BackedCandidate>); // sorted by para-id.
@@ -845,19 +845,19 @@ The overseer is responsible for these tasks:
 
 The hierarchy of subsystems:
 ```
-+--------------+      +------------------+    +--------------------+    
-|              |      |                  |---->   Subsystem A      |    
-| Block Import |      |                  |    +--------------------+    
-|    Events    |------>                  |    +--------------------+    
-+--------------+      |                  |---->   Subsystem B      |    
-                      |   Overseer       |    +--------------------+    
-+--------------+      |                  |    +--------------------+    
-|              |      |                  |---->   Subsystem C      |    
-| Finalization |------>                  |    +--------------------+    
++--------------+      +------------------+    +--------------------+
+|              |      |                  |---->   Subsystem A      |
+| Block Import |      |                  |    +--------------------+
+|    Events    |------>                  |    +--------------------+
++--------------+      |                  |---->   Subsystem B      |
+                      |   Overseer       |    +--------------------+
++--------------+      |                  |    +--------------------+
+|              |      |                  |---->   Subsystem C      |
+| Finalization |------>                  |    +--------------------+
 |    Events    |      |                  |    +--------------------+
 |              |      |                  |---->   Subsystem D      |
-+--------------+      +------------------+    +--------------------+   
-                                                  
++--------------+      +------------------+    +--------------------+
+
 ```
 
 The overseer determines work to do based on block import events and block finalization events (TODO: are finalization events needed?). It does this by keeping track of the set of relay-parents for which work is currently being done. This is known as the "active leaves" set. It determines an initial set of active leaves on startup based on the data on-disk, and uses events about blockchain import to update the active leaves. Updates lead to `OverseerSignal::StartWork` and `OverseerSignal::StopWork` being sent according to new relay-parents, as well as relay-parents to stop considering.
@@ -883,22 +883,22 @@ The overseer's logic can be described with these functions:
 
 When a subsystem wants to communicate with another subsystem, or, more typically, a job within a subsystem wants to communicate with its counterpart under another subsystem, that communication must happen via the overseer. Consider this example where a job on subsystem A wants to send a message to its counterpart under subsystem B. This is a realistic scenario, where you can imagine that both jobs correspond to work under the same relay-parent.
 
-```                                  
-     +--------+                                                           +--------+      
-     |        |                                                           |        |      
-     |Job A-1 | (sends message)                       (receives message)  |Job B-1 | 
-     |        |                                                           |        |      
-     +----|---+                                                           +----^---+      
-          |                  +------------------------------+                  ^          
-          v                  |                              |                  |          
+```
+     +--------+                                                           +--------+
+     |        |                                                           |        |
+     |Job A-1 | (sends message)                       (receives message)  |Job B-1 |
+     |        |                                                           |        |
+     +----|---+                                                           +----^---+
+          |                  +------------------------------+                  ^
+          v                  |                              |                  |
 +---------v---------+        |                              |        +---------|---------+
 |                   |        |                              |        |                   |
 | Subsystem A       |        |       Overseer / Message     |        | Subsystem B       |
 |                   -------->>                  Bus         -------->>                   |
 |                   |        |                              |        |                   |
 +-------------------+        |                              |        +-------------------+
-                             |                              |                             
-                             +------------------------------+                             
+                             |                              |
+                             +------------------------------+
 ```
 
 This communication prevents a certain class of race conditions. When the Overseer determines that it is time for subsystems to begin working on top of a particular relay-parent, it will dispatch a `StartWork` message to all subsystems to do so, and those messages will be handled asynchronously by those subsystems. Some subsystems will receive those messsages before others, and it is important that a message sent by subsystem A after receiving `StartWork` message will arrive at subsystem B after its `StartWork` message. If subsystem A maintaned an independent channel with subsystem B to communicate, it would be possible for subsystem B to handle the side message before the `StartWork` message, but it wouldn't have any logical course of action to take with the side message - leading to it being discarded or improperly handled. Well-architectured state machines should have a single source of inputs, so that is what we do here.
@@ -913,17 +913,17 @@ Furthermore, the protocols by which subsystems communicate with each other shoul
 
 #### Description
 
-The Candidate Backing subsystem is engaged in by validators in to contribute to the backing of parachain candidates submitted by other validators.
+The Candidate Backing subsystem determines whether parachain blocks are valid or not. When run as a validator or fisherman, this subsystem actually validates incoming candidates.
 
 Its role is to produce backed candidates for inclusion in new relay-chain blocks. It does so by issuing signed [Statements](#Statement-type) and tracking received statements signed by other validators. Once enough statements are received, they can be combined into backing for specific candidates.
 
 It also detects double-vote misbehavior by validators as it imports votes, passing on the misbehavior to the correct reporter and handler.
 
-When run as a validator, this is the subsystem which actually validates incoming candidates.
-
 #### Protocol
 
-This subsystem receives messages of the type [CandidateBackingSubsystemMessage](#Candidate-Backing-Subsystem-Message).
+The **Candidate Selection** subsystem is the primary source of non-overseer messages into this subsystem. That subsystem generates appropriate [`CandidateBackingSubsystemMessage`s](#Candidate-Backing-Subsystem-Message), and passes them to this subsystem.
+
+This subsystem validates the candidates and generates an appropriate `Statement`. All `Statement`s are then passed on to the **Statement Distribution** subsystem to be gossiped to peers. Instances of `Statement::Invalid` are also passed back to the Candidate Selection subsystem, so it can take action against the originator of the candidate. To reduce traffic, we do not send valid `Statement`s back to the Candidate Selection subsystem.
 
 #### Functionality
 
@@ -994,9 +994,42 @@ Dispatch a `PovFetchSubsystemMessage(relay_parent, candidate_hash, sender)` and 
 
 (TODO: send statements to Statement Distribution subsystem, handle shutdown signal from candidate backing subsystem)
 
+### Candidate Selection Subsystem
+
+#### Description
+
+The Candidate Selection subsystem monitors net traffic for two events:
+
+- a new parablock candidate is available
+- a peer has seconded a parablock candidate
+
+This module is only ever interested in parablocks assigned to the particular parachain which this validator is currently handling.
+
+New parablock candidates may arrive from a potentially unbounded set of collators. This subsystem chooses either 0 or 1 of them per relay parent to second. If it chooses to second a candidate, it sends an apropriate message to the **Candidate Backing** subsystem to generate an appropriate `Statement`.
+
+All parablocks which peers have seconded are also sent to the Candidate Backing subsystem for re-validation.
+
+In the event that a parablock candidate proves invalid, this subsystem will receive a message back from the Candidate Backing subsystem indicating so. If that parablock candidate originated from a collator, this subsystem will blacklist that collator. If that parablock candidate originated from a peer, this subsystem generates a report for the **Misbehavior Arbitration** subsystem.
+
+TODO: more details, protocol, etc
+
+### Misbehavior Arbitration Subsystem
+
+#### Description
+
+The Misbehavior Arbitration system collects reports of validator misbehavior, and slashes the stake of both misbehaving validator nodes and false accusers.
+
+#### TODOs
+
+- threshold of reports for deciding that a validator has misbehaved
+- threshold of reports for deciding that an accusation was false
+- what to do if there are enough reports to pass the first threshold, but not enough for the second
+- time period over which to collect reports
+- detailed protocol
+
 ---
 
-[TODO: subsystems for gathering data necessary for block authorship, for networking, for misbehavior reporting, etc.]
+[TODO: subsystems for gathering data necessary for block authorship, for networking, etc.]
 
 ----
 
@@ -1017,7 +1050,7 @@ struct BlockImportEvent {
   hash: Hash,
   /// The header itself.
   header: Header,
-  /// Whether this block is considered the head of the best chain according to the 
+  /// Whether this block is considered the head of the best chain according to the
   /// event emitter's fork-choice rule.
   new_best: bool,
 }
@@ -1084,9 +1117,12 @@ enum CandidateBackingSubsystemMessage {
   /// Registers a stream listener for updates to the set of backed candidates that could be included
   /// in a child of the given relay-parent, referenced by its hash.
   RegisterBackingWatcher(Hash, TODO),
-  /// Note that the Candidate Backing subsystem should second the given candidate in the context of the 
+  /// The Candidate Backing subsystem should second the given candidate in the context of the
   /// given relay-parent (ref. by hash). This candidate must be validated.
-  Second(Hash, CandidateReceipt)
+  Second(Hash, CandidateReceipt),
+  /// The only difference between the `Validate` and `Second` variants is which `Statement` variant
+  /// is returned when the candidate is valid.
+  Validate(Hash, CandidateRecipet),
 }
 ```
 
@@ -1113,11 +1149,11 @@ struct HostConfiguration {
   pub parathread_retries: u32,
   /// How often parachain groups should be rotated across parachains.
   pub parachain_rotation_frequency: BlockNumber,
-  /// The availability period, in blocks, for parachains. This is the amount of blocks 
+  /// The availability period, in blocks, for parachains. This is the amount of blocks
   /// after inclusion that validators have to make the block available and signal its availability to
   /// the chain. Must be at least 1.
   pub chain_availability_period: BlockNumber,
-  /// The availability period, in blocks, for parathreads. Same as the `chain_availability_period`, 
+  /// The availability period, in blocks, for parathreads. Same as the `chain_availability_period`,
   /// but a differing timeout due to differing requirements. Must be at least 1.
   pub thread_availability_period: BlockNumber,
   /// The amount of blocks ahead to schedule parachains and parathreads.
@@ -1135,7 +1171,7 @@ Here you can find definitions of a bunch of jargon, usually specific to the Polk
 - Backed Candidate: A Parachain Candidate which is backed by a majority of validators assigned to a given parachain.
 - Backing: A set of statements proving that a Parachain Candidate is backed.
 - Collator: A node who generates Proofs-of-Validity (PoV) for blocks of a specific parachain.
-- Extrinsic: An element of a relay-chain block which triggers a specific entry-point of a runtime module with given arguments. 
+- Extrinsic: An element of a relay-chain block which triggers a specific entry-point of a runtime module with given arguments.
 - GRANDPA: (Ghost-based Recursive ANcestor Deriving Prefix Agreement). The algorithm validators use to guarantee finality of the Relay Chain.
 - Inclusion Pipeline: The set of steps taken to carry a Parachain Candidate from authoring, to backing, to availability and full inclusion in an active fork of its parachain.
 - Module: A component of the Runtime logic, encapsulating storage, routines, and entry-points.
@@ -1165,4 +1201,4 @@ Also of use is the [Substrate Glossary](https://substrate.dev/docs/en/overview/g
 - Polkadot Runtime Spec: https://github.com/w3f/polkadot-spec/tree/spec-rt-anv-vrf-gen-and-announcement/runtime-spec
 
 [0]: https://wiki.polkadot.network/docs/en/learn-consensus
-[1]: https://github.com/w3f/polkadot-spec/tree/spec-rt-anv-vrf-gen-and-announcement/runtime-spec 
+[1]: https://github.com/w3f/polkadot-spec/tree/spec-rt-anv-vrf-gen-and-announcement/runtime-spec

--- a/docs/polkadot/implementors-guide/subsystems-overview.md
+++ b/docs/polkadot/implementors-guide/subsystems-overview.md
@@ -11,11 +11,11 @@ These subsystems comprise the Validity module. All detailed documentation lives 
 
 ## Overseer
 
-The overseer is the postal service: it relays messages between the other modules. At any time in this document when we state that a module sends a message to another, it does so via the overseer. The overseer also alerts other subsystems when they should be prepared to work on new relay parents, and when they should shut down preparations to work on old, finalized, or otherwise obsolete relay parents.
+The overseer is the postal service: it relays messages between the other subsystems. At any time in this document when we state that a subsystem sends a message to another, it does so via the overseer. The overseer also alerts other subsystems when they should be prepared to work on new relay parents, and when they should shut down preparations to work on old, finalized, or otherwise obsolete relay parents.
 
 ## Candidate Selection
 
-The candidate selection module is in charge of seconding 0 or 1 parablock candidates per relay parent.
+The candidate selection subsystem is in charge of seconding 0 or 1 parablock candidates per relay parent.
 
 ### Inbound Messages
 
@@ -27,7 +27,7 @@ The candidate selection module is in charge of seconding 0 or 1 parablock candid
 
 ## Candidate Backing
 
-The candidate backing module is in charge of producing statements which assert the (non-)validity of a parachain candidate.
+The candidate backing subsystem is in charge of producing statements which assert the (non-)validity of a parachain candidate.
 
 ### Inbound Messages
 
@@ -41,7 +41,7 @@ The candidate backing module is in charge of producing statements which assert t
 
 ## Candidate Validation
 
-The candidate validation module handles the details of validating a candidate. For any given parachain candidate, it arranges the appropriate context: the validation function, the relay parent head data, the in-progress relay data, etc.
+The candidate validation subsystem handles the details of validating a candidate. For any given parachain candidate, it arranges the appropriate context: the validation function, the relay parent head data, the in-progress relay data, etc.
 
 ### Inbound Messages
 
@@ -55,7 +55,7 @@ Responses from the Candidate Validation subsystem always return to the requester
 
 ## Statement Distribution
 
-The statement distribution module sends statements to peer nodes, detects double-voting, and tabulates when a sufficient portion of the validator set has unanimously judged a candidate. When judgment is not unanimous, it escalates the issue to misbehavior arbitration.
+The statement distribution subsystem sends statements to peer nodes, detects double-voting, and tabulates when a sufficient portion of the validator set has unanimously judged a candidate. When judgment is not unanimous, it escalates the issue to misbehavior arbitration.
 
 ### Inbound Messages
 
@@ -70,7 +70,7 @@ The statement distribution module sends statements to peer nodes, detects double
 
 ## Misbehavior Arbitration
 
-The misbehavior arbitration module kicks in when two validator nodes disagree about a candidate's validity. In this case, _all_ validators, not just those assigned to its parachain, weigh in on the validity of this candidate. The minority is slashed.
+The misbehavior arbitration subsystem kicks in when two validator nodes disagree about a candidate's validity. In this case, _all_ validators, not just those assigned to its parachain, weigh in on the validity of this candidate. The minority is slashed.
 
 ### Incoming Messages
 

--- a/docs/polkadot/implementors-guide/subsystems-overview.md
+++ b/docs/polkadot/implementors-guide/subsystems-overview.md
@@ -1,0 +1,95 @@
+# Subsystems Overview
+
+These subsystems comprise the Validity module. All detailed documentation lives within the guide; this document simply attempts to enumerate and briefly describe each subsystem and the map of their communications.
+
+- Overseer
+- Candidate Selection
+- Candidate Validation
+- Candidate Backing
+- Statement Distribution
+- Misbehavior Arbitration
+
+## Overseer
+
+The overseer is the postal service: it relays messages between the other modules. At any time in this document when we state that a module sends a message to another, it does so via the overseer. The overseer also alerts other subsystems when they should be prepared to work on new relay parents, and when they should shut down preparations to work on old, finalized, or otherwise obsolete relay parents.
+
+## Candidate Selection
+
+The candidate selection module is in charge of seconding 0 or 1 parablock candidates per relay parent.
+
+### Inbound Messages
+
+- **Overseer**: a new parablock candidate has arrived from a collator.
+
+### Outbound Messages
+
+- **Candidate Backing**: this candidate (by hash) satisfies system properties; please validate it
+
+## Candidate Backing
+
+The candidate backing module is in charge of producing statements which assert the (non-)validity of a parachain candidate.
+
+### Inbound Messages
+
+- **Candidate Selection**: a candidate which satisfies system properties
+- **Candidate Validation**: a particular candidate is valid, or not
+
+### Outbound Messages
+
+- **Candidate Validation**: is this candidate in fact valid?
+- **Statement Distribution**: I testify that this candidate is (in-)valid
+
+## Candidate Validation
+
+The candidate validation module handles the details of validating a candidate. For any given parachain candidate, it arranges the appropriate context: the validation function, the relay parent head data, the in-progress relay data, etc.
+
+### Inbound Messages
+
+- **Various Subsystems**: requests to validate a particular parablock candidate
+
+### Outbound Messages
+
+Responses from the Candidate Validation subsystem always return to the requester
+
+- **Various Subsystems**: a parablock candidate is valid, or not
+
+## Statement Distribution
+
+The statement distribution module sends statements to peer nodes, detects double-voting, and tabulates when a sufficient portion of the validator set has unanimously judged a candidate. When judgment is not unanimous, it escalates the issue to misbehavior arbitration.
+
+### Inbound Messages
+
+- **Overseer**: a peer node has seconded a candidate
+
+### Outbound Messages
+
+- **Candidate Validation**: double-check this peer's seconded candidate
+- **Peer validators**: Here's what I think about a candidate's validity
+- **Misbehavior Arbitration**: I disagree with a peer node about this candidate's validity
+- **Overseer**: a unanimous quorum of nodes has agreed about this candidate's validity
+
+## Misbehavior Arbitration
+
+The misbehavior arbitration module kicks in when two validator nodes disagree about a candidate's validity. In this case, _all_ validators, not just those assigned to its parachain, weigh in on the validity of this candidate. The minority is slashed.
+
+### Incoming Messages
+
+- **Statement Distribution**: Two validator nodes disgree on this candidate's validity, please figure it out
+- **Statement Distribution**: I noticed a validator contradicting itself about this candidate's validity, please figure it out
+
+### Outgoing Messages
+
+- **Overseer**: the majority of nodes agree that this candidate is valid/invalid; here is a list of minority voters to slash
+
+---
+
+## Tracing
+
+Let's follow a parachain candidate through the system. This follows the happy path, but we'll note exit points along the way.
+
+- Collator (external to this system)
+- Overseer
+- Candidate Selection: every parachain validator can choose at most 1 candidate to back, so potentially many are discarded.
+- Candidate Backing
+- Statement Distribution: if there's disagreement about a candidate's validity, things move to misbehavior arbitration.
+- Overseer: a quorum of validators unanimously agrees about this candidate's validity.


### PR DESCRIPTION
Note: there are a bunch of whitespace edits where my editor stripped trailing whitespace; I can edit to leave those in, but IMO it's cleaner to just fix it.