### PR TITLE
A&V networking: change topology to one more suited to different chain-sizes

### DIFF
--- a/docs/polkadot/networking/3-avail-valid.md
+++ b/docs/polkadot/networking/3-avail-valid.md
@@ -33,7 +33,7 @@ Every block is erasure coded across N pieces with a threshold of ceil(N/3).
 
 At the start of the period, for every parachain, its N/C parachain validators each have all of the N pieces. In this role we call them the "preliminary checkers". The high-level purpose of A&V networking is to:
 
-R1: Distribute the pieces of all C blocks to all other validators. A corollary of this is that every validator *must receive* at minimum (C-1) pieces, 1 from every other parachain.
+R1: Distribute the pieces of all C blocks to all other validators. A corollary of this is that every validator *must receive* at minimum (C-1) pieces - 1 from every other parachain - when operating at full capacity i.e. when every C parachain produces a block.
 
 R2: Ensure that ceil(N/3) of the pieces of all C blocks remains available and retrievable for a reasonable amount of time, across the N validators.
 
@@ -84,7 +84,7 @@ These should be gossiped every few seconds, and allows the participants to know 
 
 The data of the pieces are distributed via the following communication links:
 
-1. all validators in their in-neighbour set, as defined by in the overlay topology below
+1. all validators in their in- and out-neighbour sets, as defined by in the overlay topology below
 2. all other validators in the same preliminary-check set; this is the same as the parachain validator set
 3. all other validators in the same approval-checking set
 
@@ -120,7 +120,7 @@ We then perform the following random assignments:
     - Using the chain seed of `c`, we randomly assign a *chain-validator-index* `[0..|c|-1]` to every validator in the chain.
 - For every unordered pair of chains (`a`, `b`):
     - Using (the chain seed of `a`) XOR (the chain seed of `b`), we randomly assign a matching between the chain-validator-indexes of `a` and `b`. There are two cases:
-        - If `|a| == |b|` then the assignment can be performed straightforwardly, e.g. via a random shuffle on `[0..|a|-1]` interpreted as a matching. **Example**: if `|a| == 10` then we shuffle `[0..9]` then zip the result with `[0..9]` to get a list-of-pairs to be interpreted as bidirectional matches.
+        - If `|a| == |b|` then the assignment can be performed straightforwardly, e.g. via a random shuffle on `[0..|a|-1]` interpreted as a matching (a.k.a. bipartite graph). **Example**: if `|a| == 10` then we shuffle `[0..9]` then zip the result with `[0..9]` to get a list-of-pairs to be interpreted as bidirectional matches.
         - If `|a| == |b| + 1` then we first select an index from `b` to act as the extra index. The selected index would be `larger-chain-index(a) mod |b|`. We now can perform the random matching as above, except that the match against the extra-index goes only from `b` to `a`. **Example**: if `larger-chain-index(a) == 57`, `|a| == 11`, `|b| == 10` then we would randomly assign a matching between `[0..10]` and `[0..10]`, where `10` on the RHS is later replaced by `7`, and `7 -> (some index of a)` but not `(some index of a) -> 7`. Note that `7` also has another bidirectional match with some other index of a.
         - If `|a| + 1 == |b|` then as above, but of course flipped.
     - This matching defines part of the in-neighbours and out-neighbours of the validators of a pair of chains: for everyone in the pair of chains, it adds 1 in-neighbour, and 0, 1, or 2 out-neighbours depending on the size of the chains.

--- a/docs/polkadot/networking/3-avail-valid.md
+++ b/docs/polkadot/networking/3-avail-valid.md
@@ -127,25 +127,35 @@ We then perform the following random assignments:
 
 The above assignment can be calculated by everyone in the same way, and gives an in-neighbour-set of `C-1` for every validator, satisfying our [requirement](#high-level-requirements) R1.
 
-Some validators will have slightly more than `C-1` validators in their out-neighbour set, but we attempt to spread this evenly across the validators, satisfying our aim A3. This is what the indexes are for; without these we cannot attempt to spread the load. In summary, validators will either have `C-1`, `D-1`, or `C-1 + ceil-or-floor(D/floor(N/C))` out-neighbours, where `D == N mod C`. **Example**: if `N == 998`, `C == 100`, then this would be `{99, 97, 109, 110}`, which is not too uneven.
+Some validators will have slightly more than `C-1` validators in their out-neighbour set, but we attempt to spread this evenly across the validators, satisfying our aim A3. This is what the indexes are for; without these we cannot attempt to spread the load. In summary, validators will either have `C-1`, `D-1`, or `C-1 + ceil-or-floor(D/floor(N/C))` out-neighbours, where `D == N mod C`. **Example**: if `N == 998`, `C == 100`, then this would be `{99, 97, 109, 110}`; and if `N == 1001`, `C == 100`, then this would be `{99, 0, 99, 100}`, with only one validator having the `0`.
 
 Additionally, links are used in a bidirectional way as much as possible, helping to optimise the resource usage in terms of connections.
 
 Note: in general, KDFs require an additional input, the "security context". Typically this should be a string that is not used in any other context globally. For example the string `"polkadot A&V topology master seed, generating validator-index"`, `"polkadot A&V chain seed for chain $chain-id"`, etc, will be sufficient.
 
+### Notational definitions
+
+In the protocol phases descriptions below, we use some shorthand notation for convenience:
+
+When we refer to a validator `(c, i)`, we mean the validator on parachain with chain-index c and chain-validator-index i, as defined previously.
+
+When we have to iterate through a out-neighbour-set of some validator `(c, i)`, we do this in chain-index order. That is, for all `v` in `out-neighbour(c, i)` we iterate through the `v` in increasing order of `chain-index(v)`. Recall that these chain-index values range from `[0..C-1]`; we start the iteration at `c+1` (unless otherwise stated) and go around cyclicly, wrapping back to `0` after reaching `C-1`, then proceeding onto `c-1`. For in-neighbour sets, we start the iteration at `c-1` (unless otherwise stated), go in *decreasing* order of `chain-index(v)`, and go around cyclicly eventually reaching `c+1`.
+
+Note that for out-neighbour sets, there might be several `v` with the same `chain-index(v)`, in which case we can go through these in any order, e.g. the key-id of `v` itself.
+
 ## Protocol phase 1: initial distribution
 
-Every validator is both a distributor of C pieces and a distributee (recipient) of C pieces [TODO: correction, explanation]. Every piece has one source parachain and one main target storer, and so we can index pieces with a tuple (c_s, (c_t, i_t)) which would read as *the piece with source parachain c_s and destination validator on parachain c_t with index i_t*.
+As described in detail above, every validator is both a distributor of roughly C pieces and a distributee (recipient) of (C-1) pieces. Every piece has one source parachain and one main target-storer, and so we can index pieces with a tuple `piece(c_s, v_t)` which would read as *the piece with source parachain `c_s` and destination validator `v_t`*. `c_s` is a chain-index, and `v_t` is a validator-index as defined previously.
 
-In phase 1, pieces are distributed by the source parachain validators (c_s, *) to the main target storers. This happens in two stages. Stage A is where most of the material is distributed, and stage B acts as a backup mechanism for anything that was missed during stage A.
+In phase 1, pieces are distributed by the source parachain validators to the main target-storers. This happens in two stages. Stage A is where most of the material is distributed, and stage B acts as a backup mechanism for anything that was missed during stage A.
 
 **Stage A**
 
-As a distributor, each validator (c, i) attempts to send the relevant pieces for their parachain's block (c, (c', i)), to everyone else on their ring (c', i) for all c' != c. Conversely as a distributee, each validator expects to receive their relevant pieces (c', (c, i)) for other parachains' blocks, from everyone else on their ring (c', i) for all c' != c.
+As a distributor, each validator `(c, i)` attempts to send the relevant pieces to everyone else in their out-neighbour set, i.e. `piece(c, v) for v in out-neighbour(c, i)`, iterating in order described previously. Conversely as a distributee, each validator `(c, i)` expects to receive their relevant pieces from everyone else in their in-neighbour set, i.e. `piece(chain-index(v), i) for v in in-neighbour(c, i)`.
 
 In more detail:
 
-Each distributor (c, i) will, with parallelism = C / 4, for s in [0..C), try to send the relevant piece to target t = ((c+s) mod C, i). C / 4 comes from our estimate that T_b ~= 4 * T_L.
+Each distributor `(c, i)` will, with parallelism = C / 4, iterate through the neighbour-set, trying to send the relevant piece to each target `v`. C / 4 comes from our estimate that `T_b ~= 4 * T_L`.
 
 Trials are done with a timeout, slightly larger than T_l. Sending is via QUIC. In order for it to be treated as a success, it should include an acknowledgement of receipt. Note this is orthogonal from the gossiped receipts which include a validator signature; by contrast this transport-level receipt can be assumed to be already protected by QUIC [transport authentication](L-authentication.html).
 
@@ -153,11 +163,11 @@ If a gossiped receipt is received at any point during the whole process, for a t
 
 **Stage B**
 
-As a distributee, if after a grace period we still haven't received our piece (c', (c, i)) from a parachain validator (c', i), then we will ask the other validators (c', i') for all i' != i (from all other rings) in that parachain for the piece (c', (c, i)), load-balanced as described in more detail below.
+As a distributee, if after a grace period we still haven't received our piece from a validator in our in-neighbour set, say from a validator on parachain `c'`, then we will ask the other validators on that parachain `c'` for the piece, load-balanced as described in more detail below.
 
 This gives the distributee a more direct level of control over obtaining their own pieces.
 
-As a distributor, if after our own stage A process is finished, we have received fewer than ceil(N/3) of the receipts of another ring i' - i.e. receipts for piece (c, (c', i')) from peer (c', i') for all c' - then we will begin the stage A process for the other ring i' too, load-balanced as described in more detail below.
+As a distributor, if after our own stage A process is finished, we have received fewer than ceil(N/3) of the receipts of `out-neighbour(c, i')` for some other `i'` - then we will begin the stage A process for this out-neighbour set too, load-balanced as described in more detail below.
 
 This helps to handle cases where a distributor validator is unavailable for everyone, either due to severe network issues or due to malicious behaviour. In this case, we hope to save a bit of latency by pro-actively distributing these pieces before being asked for them.
 
@@ -165,11 +175,11 @@ This helps to handle cases where a distributor validator is unavailable for ever
 
 In more detail, for load-balancing purposes we suggest the following:
 
-For distributees (c, i) expecting a piece from distributor (c', i), the grace period they wait for should be 2 * T_L plus the expected slot time T_b / C * s where s = (c - c') mod C as defined in stage A, before asking other alternative distributors for the piece. When doing so, say from distributors (c', i') with fixed c', varying i', they should start with i' = (i + ((s + 1) mod (N/C - 1))) mod N/C first.
+For distributees `(c, i)` expecting a piece from distributor `(c', i') for some i' in in-neighbour(c, i)`, the grace period they wait for should be `2 * T_L` plus the expected slot time `T_b / C * s` where `s = (c - c') mod C` as defined in stage A, before asking other alternative distributors for the piece. When doing so, say from distributors `(c', i'')` with fixed `c'`, varying `i'' != i'`, they should start with `i'' = i' + v mod chain-size(c')` first, where `v` is the distributee's validator-index, then increasing `i''` until wrapping around back to `i' + v - 1`.
 
-For distributors (c, i) when distributing to another ring i' that is missing too many receipts, they should prioritise rings by the directed distance d = (i' - i) mod N/C from their own ring, and start the traversal around the ring from (c + s, i') with s = C * (i' - i) / (N/C), of course skipping targets for whom a receipt has already been received.
+For distributors `(c, i)` when distributing to another set `out-neighbour(c, i')` that is missing too many receipts, they should prioritise sets by the signed difference `d = (i' - i) mod |chain-size(c)|` between the chain-validator-indexes, and iterate through the set skipping targets for whom a receipt has already been received. The iteration should start from `c + 1 + floor(d*R)`, where `R = (|out-neighbour(c, i')| - 1) / (|chain-size(c)| - 1)`, which load-balances across any other distributor in chain `c` that might also be distributing to `out-neighbour(c, i')`.
 
-For example, with C = 100 and N/C = 10, a distributor (57, 3) who has finished distributing to (\*, 3) and observes that rings 2, 4 and 7 are missing too many receipts, would proceed to distribute to (67, 4), (68, 4), (69, 4) and so on, skipping anyone whose receipts have already been received.
+For example, with `C == 100` and `N/C == 10`, a distributor (57, 3) who has finished distributing to `out-neighbour(57, 3)` and observes that `out-neighbour(57, 2)`, `out-neighbour(57, 4)`, `out-neighbour(57, 7)` are missing too many receipts, would proceed to distribute to validators from `out-neighbour(57, 4)` with chain-index `69 == 57 + 1 + 1*(99/9)`, then 70, 71 and so on, skipping anyone whose receipts have already been received.
 
 ## Protocol phase 2: approval checking
 
@@ -183,8 +193,9 @@ Unlike phase 1, distributees do not need to broadcast receipts for every individ
 
 Stage A of phase 2 proceeds similarly to stage A of phase 1, except that:
 
-- Each distributor only needs to distribute to the half-ring in front of it, instead of the whole ring. This is 3/2 of the minimum ceil(N/3) required, which should give a generous margin for success.
-- Each distributor (c, i), when sending to target (c', i) for some given c' != c, does not send piece (c, (c', i)) as they would in phase 1, but rather the pieces (c, (v, i)) for all parachains v that c' is a approval checker for, and for which c has not received a gossiped receipt from c' for.
+- Each distributor `(c, i)` only distributes to half of its out-neighbour set, instead of the whole set. This is 3/2 of the minimum `ceil(N/3)` required, which should give a generous margin for success. As a concrete decision, this would be the first half of the standard iteration order as described previously, of length `ceil(C/2) - 1`.
+
+- Each distributor `(c, i)`, when sending to target `v` does not send piece `(c, v)` as they would in phase 1, but rather `piece(c, v')` for all `v'` in `out-neighbour(c, i)`) where `chain-index(v') == c_v` and `v` is an approval checker for `c_v`, and for which they have not received a gossiped receipt from `v` for. The number of parachains assigned to each approval checker will be not too much higher than 1.
 
 By re-using the basic structure from phase 1, we also automatically gain its other nice properties such as load-balancing.
 
@@ -192,11 +203,11 @@ By re-using the basic structure from phase 1, we also automatically gain its oth
 
 Stage B of phase 2 is morally similar to stage B of phase 1, but ends up being structurally quite different, due to the different high-level requirements.
 
-Each distributee (c, i) is not expecting any specific pieces from anyone, but rather ceil(N/3) pieces of the block from every parachain v for which it is a approval checker. After a grace period of 2 * T_L, if they have not received enough pieces for any v, they will begin querying other validators for their pieces for these blocks.
+Each distributee `(c, i)` is not expecting any specific pieces from anyone, but rather `ceil(N/3)` pieces of the block from every parachain `c_v` for which it is a approval checker. After a grace period of `2 * T_L`, if they have not received enough pieces for any `c_v`, they will begin querying other validators for their pieces for these blocks.
 
-For load-balancing, this querying of other validators (c', i') begins at c' = c + 1, i' = i, increasing c' then increasing i'. This means that the last validators to be queried will be (c, i - i/2) to (c, i - 1) which precisely are the ones that (are supposed to) have sent us pieces already in stage A, so we avoid duplication.
+For load-balancing, this querying of other in-neighbour sets begins at `in-neighbour(c, i')`, starting with `i' = i + 1`, increasing until it wraps around back to `i`. The iteration through each in-neighbour set starts from `c - ceil(C/2) mod C`, with decreasing chain-index as described previously. This means that the last validators to be queried will be precisely the ones that (are supposed to) have sent us pieces already in stage A, helping to avoid duplication.
 
-At any time, if the distributee receives ceil(N/3) or more pieces of the blocks of every parachain v for which they are a approval checker for, they can cancel the above process with success.
+At any time, if the distributee receives `ceil(N/3)` or more pieces of the blocks of every parachain `c_v` for which they are a approval checker for, they can cancel the above process with success.
 
 Each distributor is responsible for a smaller fraction of the required pieces for each block, by design. Therefore, we don't need a separate follow-up part for distributors.
 


### PR DESCRIPTION
This new topology is closer to what @burdges was suggesting originally - a bit more complex, based on matching between pairs of chains, rather than the old ring-based one. However it's much easier to get working when C (num chains) does not evenly divide N (num validators).

There are a few similarities though, to help you understand it. When C does divide N, the ring-based one can appear as one special case of this new topology. Everyone has an in-neighbour set and an out-neighbour set, the difference is that this is not expected to be shared across chains. However, all the load-balancing logic can be re-written in terms of these neighbour sets, and that's also included in this PR.

I've defined the randomness seeds quite precisely, they might be different from jeff's original proposal but only because I can't remember what the details are. Variations on the general structure will all work, e.g. using some other symmetric function than XOR.