### PR TITLE
XCMP: move communication model & fairness sections from networking to main protocol doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.githubpages',
+    'sphinx.ext.autosectionlabel',
     'sphinx_material',
 ]
 
@@ -75,6 +76,8 @@ mathjax_config = {
 }
 
 # -- Extension configuration -------------------------------------------------
+
+autosectionlabel_prefix_document = True
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/polkadot/XCMP/index.md
+++ b/docs/polkadot/XCMP/index.md
@@ -16,7 +16,39 @@ Ordered and timely delivery of messages is not a given in many applications such
 
 (For comparison, while Cosmos allows the choice of having ordered delivery, there may be no guarantees that messages will ever arrive due to the lack of a general incentive model for this purpose.)
 
-We want all these properties while maintaining scalability, in that the relay chain should not be overwhelemed if 100 parachains send messages to 10,000 destinations in a single relay chain block, which we discuss in the next sections.
+We want all these properties while maintaining scalability, in that the relay chain should not be overwhelemed if 100 parachains send messages to 10,000 destinations in a single relay chain block, which we discuss in the next sections. This includes trying to minimise the data stored on the relay chain, and in particular it should be constant or near-constant with respect to the message body sizes.
+
+
+## Communication model
+
+This section talks about the XCMP communication interface from the viewpoint of a parachain, without going into the internal details on how this interface is implemented, or how its guarantees are achieved, by Polkadot.
+
+Parachains can send each other mesages once they have established messaging channels with each other.
+Every (sender, recipient) parachain pair can have up to 1 open channel, allowing for bidirectional communication.
+
+Whilst the channel is open, it contains a bounded queue of ordered messages that have been sent but not yet acknowledged by the recipient. The sender may add a message to the back of the queue (i.e. send a message), and the recipient may remove a message from the front of the queue (i.e. ack a message), by indicating as such in their respective next submission to the relay chain. Sender and recipient parachains are also expected to monitor the state of the relay chain, in order to know what is currently in the queue.
+
+Note: all the messages for a given (sender, relay-chain block) are processed in a single batch by the recipient, so to simplify discussion without losing generality, from here on we will refer to "the" (logical) message at a given (sender, relay-chain block) even though in practise this consists of multiple smaller application-level messages.
+
+The Polkadot relay chain & parachain validators together verify that the channel grows & is consumed, in a consistent & reliable way - for details see [authentication for consistent history](#authentication-for-consistent-history) below. They also enforce other guarantees such as boundedness as mentioned, and also *fairness* which we detail below.
+
+### Fairness
+
+Any given receiving parachain may have multiple incoming channels from different sending parachains. In XCMP we guarantee that a recipient must process these incoming messages **fairly** across all senders.
+
+Specifically, the order in which messages from different senders/channels must be acknowledged, is pre-determined and out of the control of the receiving parachain. In other words, multiple incoming channels for a given recipient are multiplexed into a single ingress queue, and the recipient must process this queue in the aforementioned pre-determined order. Additionally, a receiving parachain must acknowledge at least one new message from a block, if it has any new messages (from different senders/channels) in that block, to ensure liveness.
+
+We provide this guarantee of fairness, mostly to ensure that no message will be left unprocessed for an infinite delay - the sender knows that the receiver must least ack its contents eventually, though they can drop the message after that. This is a value judgement made at the point-of-design of XCMP; we'll monitor its performance in practise.
+
+Although different from the internet's recipient-controlled processing, fairness does not introduce much overhead since for global ordering and reliability, message-passing is co-ordinated via the relay chain anyways, and enforcing fairness on top of this is straightforward.
+
+If receiving parachains feel that they are being spammed by certain sending parachains, they may selectively close these channels.
+
+### More on channels
+
+Polkadot restricts how many different receiving chains a sending chain can send messages to. This is because sending and receiving messages to or from many chains requires resources. The authentication requires that the sending chain informs the relay chain which chains it is sending messages to. A collator of the receiving chain needs to look up data on the relay chain for every chain that could send a message. Both the sending and receiving side may need to implement queues in their state.
+
+This restriction is enforced by allowing XCMP only between pairs of parachain who have set up channels with each other. A parathread is restricted to have at most 100 channels. We also restrict the total number of channels accross all chains in Polkadot by requiring a deposit for each channel. Since a channel requires an ongoing commitment from both sides, setting up a channel requires the permission of both chains.
 
 
 ## Authentication for consistent history
@@ -30,13 +62,11 @@ A fork of the Polkadot relay chain defines a possible history of Polkadot. For p
 Once they are included, the parachain will act on messages in order.
 
 
-## Channels
+## Expected usage profile
 
-Polkadot allows parachains to send each other mesages as long as they have established messaging channels with each other.
+Every sending parachain may send up to ~1 MB per chain height in total, to all parachains. In the most unbalanced case, this will be all to a single receiving parachain.
 
-Polkadot restricts how many different receiving chains a sending chain can send messages to. This is because sending and receiving messages to or from many chains requires resources. The authentication requires that the sending chain informs the relay chain which chains it is sending messages to. A collator of the receiving chain needs to look up data on the relay chain for every chain that could send a message. Both the sending and receiving side may need to implement queues in their state.
-
-This restriction is enforced by allowing XCMP only between pairs of parachain who have set up channels with each other. A parathread is restricted to have at most 100 channels. We also restrict the total number of channels accross all chains in Polkadot by requiring a deposit for each channel. Since a channel requires an ongoing commitment from both sides, setting up a channel requires the permission of both chains.
+Across all chains then, the worst case is that (C-1) parachains will each send ~1 MB to the same receiver parachain in a single block; however this need not be all distributed during the time slot for that block - see [fairness](#fairness) above.
 
 
 ## Networking


### PR DESCRIPTION
The content fits better in the new place. This PR is to check that I got the details right.