### PR TITLE
pdf.js: rewrite validateFileURL to use file whitelist

### DIFF
--- a/docs/_static/pdfview/viewer.js
+++ b/docs/_static/pdfview/viewer.js
@@ -2161,7 +2161,8 @@ var PDFViewerApplication = {
 exports.PDFViewerApplication = PDFViewerApplication;
 var validateFileURL;
 {
-  var HOSTED_VIEWER_ORIGINS = ["null", "http://mozilla.github.io", "https://mozilla.github.io"];
+  var HOSTED_VIEWER_ORIGINS = ["null"];
+  var VALID_EXTERNAL_ORIGINS = ["https://w3f.github.io"];
 
   validateFileURL = function validateFileURL(file) {
     if (file === undefined) {
@@ -2179,7 +2180,7 @@ var validateFileURL;
           origin = _URL.origin,
           protocol = _URL.protocol;
 
-      if (origin !== viewerOrigin && protocol !== "blob:") {
+      if (origin !== viewerOrigin && protocol !== "blob:" && !VALID_EXTERNAL_ORIGINS.includes(origin)) {
         throw new Error("file origin does not match viewer's");
       }
     } catch (ex) {

--- a/docs/_static/pdfview/viewer.js
+++ b/docs/_static/pdfview/viewer.js
@@ -2161,35 +2161,26 @@ var PDFViewerApplication = {
 exports.PDFViewerApplication = PDFViewerApplication;
 var validateFileURL;
 {
-  var VALID_EXTERNAL_ORIGINS = ["https://w3f.github.io"];
+  var HOSTED_VIEWER_ORIGINS = ["null", "http://mozilla.github.io", "https://mozilla.github.io"];
 
   validateFileURL = function validateFileURL(file) {
+    if (file === undefined) {
+      return;
+    }
 
     try {
-      if (file === undefined) {
-        throw new Error("file to view not defined");
-      }
-
       var viewerOrigin = new URL(window.location.href).origin || "null";
 
-      if (viewerOrigin === "null") {
+      if (HOSTED_VIEWER_ORIGINS.includes(viewerOrigin)) {
         return;
       }
 
       var _URL = new URL(file, window.location.href),
-          fileOrigin = _URL.origin,
-          fileProtocol = _URL.protocol;
+          origin = _URL.origin,
+          protocol = _URL.protocol;
 
-      if (fileProtocol === "blob:") {
-        throw new Error("blob protocol disabled");
-      }
-
-      if (VALID_EXTERNAL_ORIGINS.includes(fileOrigin)) {
-        return;
-      }
-
-      if (fileOrigin !== viewerOrigin) {
-        throw new Error("file origin external and not whitelisted");
+      if (origin !== viewerOrigin && protocol !== "blob:") {
+        throw new Error("file origin does not match viewer's");
       }
     } catch (ex) {
       var message = ex && ex.message;
@@ -4669,7 +4660,7 @@ var defaultOptions = {
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   defaultUrl: {
-    value: "",
+    value: "compressed.tracemonkey-pldi-09.pdf",
     kind: OptionKind.VIEWER
   },
   defaultZoomValue: {

--- a/docs/_static/pdfview/viewer.js
+++ b/docs/_static/pdfview/viewer.js
@@ -2161,26 +2161,35 @@ var PDFViewerApplication = {
 exports.PDFViewerApplication = PDFViewerApplication;
 var validateFileURL;
 {
-  var HOSTED_VIEWER_ORIGINS = ["null", "http://w3f.github.io", "https://w3f.github.io"];
+  var VALID_EXTERNAL_ORIGINS = ["https://w3f.github.io"];
 
   validateFileURL = function validateFileURL(file) {
-    if (file === undefined) {
-      return;
-    }
 
     try {
+      if (file === undefined) {
+        throw new Error("file to view not defined");
+      }
+
       var viewerOrigin = new URL(window.location.href).origin || "null";
 
-      if (HOSTED_VIEWER_ORIGINS.includes(viewerOrigin)) {
+      if (viewerOrigin === "null") {
         return;
       }
 
       var _URL = new URL(file, window.location.href),
-          origin = _URL.origin,
-          protocol = _URL.protocol;
+          fileOrigin = _URL.origin,
+          fileProtocol = _URL.protocol;
 
-      if (origin !== viewerOrigin && protocol !== "blob:") {
-        throw new Error("file origin does not match viewer's");
+      if (fileProtocol === "blob:") {
+        throw new Error("blob protocol disabled");
+      }
+
+      if (VALID_EXTERNAL_ORIGINS.includes(fileOrigin)) {
+        return;
+      }
+
+      if (fileOrigin !== viewerOrigin) {
+        throw new Error("file origin external and not whitelisted");
       }
     } catch (ex) {
       var message = ex && ex.message;
@@ -4660,7 +4669,7 @@ var defaultOptions = {
     kind: OptionKind.VIEWER + OptionKind.PREFERENCE
   },
   defaultUrl: {
-    value: "compressed.tracemonkey-pldi-09.pdf",
+    value: "",
     kind: OptionKind.VIEWER
   },
   defaultZoomValue: {


### PR DESCRIPTION
As it turns out I misunderstood the purpose of `validateFileURL` in my previous PR, so this changes the function to an actual whitelist of external pdf resources.

- Disables use of `defaultURL` if no file is supplied
- Disables use of `blob:` protocol as file source
- Only viewer origin that disables check now is when run locally (i.e. when developing)
- All non-local pdf files are checked against whitelist