### PR TITLE
Fix formula for transaction fees

### DIFF
--- a/docs/polkadot/overview/2-token-economics.md
+++ b/docs/polkadot/overview/2-token-economics.md
@@ -209,7 +209,7 @@ As mentioned earlier, part of the tx fee needs to go to the block producer, to i
 
 A transaction fee tx is computed as follows:
 
-$$fee(tx) = base\_fee + type(tx)\cdot length(tx) + c_{traffic} \cdot \Big[ weight(tx)\Big],$$
+$$fee(tx) = base\_fee + type(tx) \cdot length(tx) + c_{traffic} \cdot weight(tx),$$
 
 where $c_{traffic}$ is a parameter independent from the transaction, that evolves over time depending on the network traffic; we explain this parameter in the next subsection. Parameter $type(tx)$ depends on the transaction type only; in particular for operational transactions, we currently set $type(tx)$ to zero.
 
@@ -235,7 +235,7 @@ where the normal length limit (the block length limit on normal transactions) is
 
 **Adjustable parameter** Let \(s^*\) be our target block saturation level. This is our desired long-term average of the block saturation level (relative to normal txs). We originally suggest \(s^*=0.25\), so that blocks are 25% full on average and the system can handle sudden spikes of up to 4x the average volume of normal transactions. This parameter can be adjusted depending on the observed volumes during spikes compared to average volumes, and in general it provides a trade-off between higher average fees and longer transaction inclusion times during spikes.
 
-Recall that a transaction fee is computed as $fee(tx) = c_{traffic} \cdot \Big[ base\_fee + type(tx)\cdot length(tx) + weight(tx)\Big]$, for a parameter $c_{traffic}$ that is independent of the transaction. Let \(s\) be the saturation level of the current block. If \(s>s^*\) we slightly increase $c_{traffic}$, and if \(s<s^*\) we slightly decrease it.
+Recall that a transaction fee is computed as $fee(tx) = base\_fee + type(tx) \cdot length(tx) + c_{traffic} \cdot weight(tx)$, for a parameter $c_{traffic}$ that is independent of the transaction. Let \(s\) be the saturation level of the current block. If \(s>s^*\) we slightly increase $c_{traffic}$, and if \(s<s^*\) we slightly decrease it.
 
 **Adjustable parameter:** Let $v$ be a fee variability factor, which controls how quickly the transaction fees adjust. We update $c_{traffic}$ from one block to the next as follows:
 


### PR DESCRIPTION
This PR removes the unnecessary brackets from the first appearance of the formula for transaction fees and fixes an incorrectly placed bracket in the second appearance of the formula.

Here's a link to the correct formula in the code: https://github.com/paritytech/substrate/blob/b75a253f148aa36fa17cf795b9f2fc2f22d0fcc5/frame/transaction-payment/src/lib.rs#L508-L533